### PR TITLE
Address eager loading issue in tests

### DIFF
--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -15,6 +15,7 @@ Rails.application.configure do
   # this probably isn't necessary. It's a good idea to do in a continuous integration
   # system, or in some way before deploying your code.
   config.eager_load = ENV["CI"].present?
+  Rails.application.eager_load! if ENV["CI"].present?
 
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true


### PR DESCRIPTION
・Closes #2.

## `CableReady` within eager load namespaces
I think the most confusing thing about this is that the constants actually show up when looking into the namespaces and running the autoloaders log.

```ruby
# test/dummy/config/environments/test.rb
p config.eager_load_namespaces
#=> [I18n, ActiveSupport, ..., CableReady::Engine, Dummy::Application]
# CableReady::Engine is here, just like in the starter repo.

# test/dummy/config/application.rb
# Add this line after `config.load_defaults Rails::VERSION::STRING.to_f` and run the tests
Rails.autoloaders.log!
#=> Zeitwerk@rails.main: the namespace CableReady already exists, descending into /home/gazayas/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/cable_ready-5.0.0.pre9/app/models/concerns/cable_ready
#=> Zeitwerk@rails.main: autoload set for CableReady::Updatable, to be autovivified from /home/gazayas/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/cable_ready-5.0.0.pre9/app/models/concerns/cable_ready/updatable
#=> Zeitwerk@rails.main: earlier autoload for CableReady::Updatable discarded, it is actually an explicit namespace defined in /home/gazayas/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/cable_ready-5.0.0.pre9/app/models/concerns/cable_ready/updatable.rb
#=> Zeitwerk@rails.main: autoload set for CableReady::Updatable, to be loaded from /home/gazayas/.rbenv/versions/3.1.1/lib/ruby/gems/3.1.0/gems/cable_ready-5.0.0.pre9/app/models/concerns/cable_ready/updatable.rb
```

`config.eager_load` is definitely being set to `true` in the test environment too, so it’s a little difficult to see why it's being affected the way it is.

## Potentially a multithreaded issue

Without pushing anything to `config.eager_load_namespaces`, simply running `Rails.application.eager_load!` will ensure all the constants we need are loaded, so the tests pass without a problem. [The Rails docs](https://edgeguides.rubyonrails.org/autoloading_and_reloading_constants_classic_mode.html#autoloading-in-the-test-environment) say the following about `eager_load!`:
> Occasionally you may need to explicitly eager_load by using `Rails.application.eager_load!` in the setup of your tests – this might occur if your tests involve multithreading.

Looking into other packages like `bullet_train-super_scaffolding` and `bullet_train-api`, I can see that the gemspec has `bullet_train` base as a dependency. I figured that was the issue since `enable_updates` is being called there, but `CI=true rails test` runs fine for `bullet_train-super_scaffolding`.

If we at least need to ensure eager loading does get done though, we can use `Rails.application.eager_load!` until we find the main cause.

## Failing tests
As you can see in CircleCI, the error is different so it looks like `CableReady::Updatable` is being loaded.