### PR TITLE
Use a hash when declaring color picker options

### DIFF
--- a/app/views/themes/tailwind_css/fields/_color_picker.html.erb
+++ b/app/views/themes/tailwind_css/fields/_color_picker.html.erb
@@ -17,7 +17,7 @@ value = form.object.send(method)
     <div class="space-x-1" data-controller="<%= stimulus_controller %>" data-<%= stimulus_controller %>-initial-color-value="<%= value %>">
       <%= form.hidden_field method, value: value, data: {"#{stimulus_controller}-target": "colorPickerValue"} %>
       <div class="inline space-x-1" data-<%= stimulus_controller %>-target="colorOptions">
-        <% options.each do |color| %>
+        <% options[:color_picker_options].each do |color| %>
           <label class="btn-toggle btn-color-picker">
             <button type="button" class="button-color mb-1.5 dark:ring-offset-sealBlue-400 <%= color == value ? 'ring-2 ring-offset-2' : '' %>" style="background-color: <%= color %>; --tw-ring-color: <%= color %>" data-action="<%= stimulus_controller %>#pickColor" data-color="<%= color %>">&nbsp;</button>
           </label>


### PR DESCRIPTION
Uses the hash value declared in [bullet_train-super_scaffolding#37](https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/37).

Using both that PR and this one will ensure the new test in [bullet_train#39](https://github.com/bullet-train-co/bullet_train/pull/39) passes.