### PR TITLE
Options: allow laying out as columns

### DIFF
--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -14,7 +14,7 @@ labels = labels_for(form, method)
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <div class="pt-1.5 pb-1 sm:col-span-2">
-      <div class="max-w-lg <%= "columns-[15ch_3]" if use_columns %>">
+      <div class="max-w-lg <%= "columns-[var(--column-width,_15ch)_3]" if use_columns %>">
 
         <% options.each do |value, label| %>
 

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -14,7 +14,7 @@ labels = labels_for(form, method)
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <div class="pt-1.5 pb-1 sm:col-span-2">
-      <div class="max-w-lg <%= "columns-[var(--column-width,_15ch)_3]" if use_columns %>">
+      <%= tag.div class: ["max-w-lg": !use_columns, "max-w-3xl": use_columns, "columns-[var(--column-width,_15ch)_3]": use_columns] do %>
 
         <% options.each do |value, label| %>
 
@@ -40,7 +40,7 @@ labels = labels_for(form, method)
 
         <% end %>
 
-      </div>
+      <% end %>
     </div>
   <% end %>
 <% end %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -5,6 +5,7 @@ form ||= current_fields_form
 html_options ||= {}
 html_options[:id] ||= id_for(form, method)
 multiple ||= false
+use_columns ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
@@ -13,7 +14,7 @@ labels = labels_for(form, method)
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <div class="pt-1.5 pb-1 sm:col-span-2">
-      <div class="max-w-lg space-y-3">
+      <div class="max-w-lg space-y-3 <%= "columns-[15ch_3]" if use_columns %>">
 
         <% options.each do |value, label| %>
 

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -14,11 +14,11 @@ labels = labels_for(form, method)
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <div class="pt-1.5 pb-1 sm:col-span-2">
-      <div class="max-w-lg space-y-3 <%= "columns-[15ch_3]" if use_columns %>">
+      <div class="max-w-lg <%= "columns-[15ch_3]" if use_columns %>">
 
         <% options.each do |value, label| %>
 
-          <label class="relative flex items-start">
+          <label class="relative flex items-start mb-3">
             <div class="flex items-center h-5">
 
               <% if multiple %>


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-fields/issues/21

On the `render` call, pass `use_columns: true` and the options will be laid out on up to three columns, defaulting to a minimum column width of 15ch.

<img width="732" alt="CleanShot 2022-08-04 at 17 31 21@2x" src="https://user-images.githubusercontent.com/104179/182956442-06bb3c44-0cfd-4245-8df3-a11da4c4cbcd.png">