### PR TITLE
Set `checked` to `nil` if a multiple option value hasn't been selected yet

### DIFF
--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -8,9 +8,6 @@ multiple ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
-
-
-
 %>
 
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -8,6 +8,9 @@ multiple ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
+
+
+
 %>
 
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
@@ -21,7 +24,8 @@ labels = labels_for(form, method)
             <div class="flex items-center h-5">
 
               <% if multiple %>
-                <%= form.check_box method, {multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s), class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
+                <% checked_value = form.object.send(method).nil? ? nil : form.object.send(method).map(&:to_s).include?(value.to_s) %>
+                <%= form.check_box method, {multiple: multiple, checked: checked_value, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
               <% else %>
                 <%= form.radio_button method, value, {class: "focus:ring-blue h-4 w-4 text-blue border-gray-300"} %>
               <% end %>


### PR DESCRIPTION
Records with multiple options try to find checked values, but this will break on the `new` action since `form.object.send(method)` is `nil`, causing `form.object.send(method).map(&:to_s).include?(value.to_s)` to break.

This fix ensures multiple options don't need a value to be displayed in forms.

Tests for this can be found in the following starter repository joint PR.

Joint PRs
- https://github.com/bullet-train-co/bullet_train/pull/347
- https://github.com/bullet-train-co/bullet_train-super_scaffolding/pull/51