### PR TITLE
Allow options field to show Select All checkbox for multiple options, with ability to reset to original selected options

### DIFF
--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -12,6 +12,17 @@ show_select_all_bottom ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
+option_field_options ||= {}
+option_field_options[:data] ||= {}
+if multiple
+  option_field_options[:data] = option_field_options[:data].merge({
+    "#{stimulus_controller}-target": 'checkbox'
+  })
+  option_field_options[:data][:controller] ||= ""
+  option_field_options[:data][:controller] += " fields--field"
+  option_field_options[:data][:action] ||= ""
+  option_field_options[:data][:action] += " #{stimulus_controller}#updateSelectAllCheckbox"
+end
 %>
 
 <% if multiple && (show_select_all_top || show_select_all_bottom) %>
@@ -57,9 +68,13 @@ labels = labels_for(form, method)
             <div class="flex items-center h-5">
 
               <% if multiple %>
-                <%= form.check_box method, {multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s), data: { "#{stimulus_controller}-target": 'checkbox', 'action': "#{stimulus_controller}#updateSelectAllCheckbox" }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
+                <%= form.check_box method, {
+                  multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s),
+                  data: option_field_options[:data],
+                  class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"
+                }, value, "" %>
               <% else %>
-                <%= form.radio_button method, value, {class: "focus:ring-blue h-4 w-4 text-blue border-gray-300"} %>
+                <%= form.radio_button method, value, {class: "focus:ring-blue h-4 w-4 text-blue border-gray-300", data: option_field_options[:data]} %>
               <% end %>
 
             </div>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -1,6 +1,8 @@
 <% yield %>
 
 <%
+stimulus_controller = 'fields--date'
+
 form ||= current_fields_form
 html_options ||= {}
 html_options[:id] ||= id_for(form, method)
@@ -12,7 +14,7 @@ labels = labels_for(form, method)
 
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
-    <div class="pt-1.5 pb-1 sm:col-span-2">
+    <div class="pt-1.5 pb-1 sm:col-span-2" data-controller="<%= stimulus_controller %>">
       <div class="max-w-lg space-y-3">
 
         <% options.each do |value, label| %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -1,7 +1,7 @@
 <% yield %>
 
 <%
-stimulus_controller = 'fields--date'
+stimulus_controller = 'fields--options'
 
 form ||= current_fields_form
 html_options ||= {}
@@ -23,7 +23,7 @@ labels = labels_for(form, method)
             <div class="flex items-center h-5">
 
               <% if multiple %>
-                <%= form.check_box method, {multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s), class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
+                <%= form.check_box method, {multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s), data: { "#{stimulus_controller}-target": 'checkbox', 'action': "#{stimulus_controller}#updateSelectedIds" }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
               <% else %>
                 <%= form.radio_button method, value, {class: "focus:ring-blue h-4 w-4 text-blue border-gray-300"} %>
               <% end %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -17,10 +17,13 @@ labels = labels_for(form, method)
 <% if multiple && (show_select_all_top || show_select_all_bottom) %>
   <% select_all = capture do %>
     <%= tag.div class: [
+        "hidden",
         "inline-block dark:border-darkPrimary-600",
         "border-b pb-4 mb-4": show_select_all_top && !show_select_all_bottom,
         "border-t pt-4 mt-4": !show_select_all_top && show_select_all_bottom
-    ] do %>
+    ], data: {
+      "#{stimulus_controller}-target": "selectAllWrapper"
+    } do %>
       <label class="relative flex items-start">
         <div class="flex items-center h-5">
           <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
@@ -38,7 +41,10 @@ labels = labels_for(form, method)
 
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
-    <div class="pt-1.5 pb-1 sm:col-span-2" data-controller="<%= stimulus_controller %>">
+    <%= tag.div class: "pt-1.5 pb-1 sm:col-span-2", data: {
+      controller: stimulus_controller,
+      "#{stimulus_controller}-select-all-unavailable-class": "hidden"
+    } do %>
     
       <% if multiple && show_select_all_top && !show_select_all_bottom %>
         <%= select_all %>
@@ -74,6 +80,6 @@ labels = labels_for(form, method)
         <%= select_all %>
       <% end %>
 
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -12,17 +12,20 @@ show_select_all_bottom ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
+
 option_field_options ||= {}
 option_field_options[:data] ||= {}
+option_field_options[:data][:controller] ||= ""
+option_field_options[:data][:controller] += " fields--field"
+
 if multiple
   option_field_options[:data] = option_field_options[:data].merge({
     "#{stimulus_controller}-target": 'checkbox'
   })
-  option_field_options[:data][:controller] ||= ""
-  option_field_options[:data][:controller] += " fields--field"
   option_field_options[:data][:action] ||= ""
   option_field_options[:data][:action] += " #{stimulus_controller}#updateSelectAllCheckbox"
 end
+
 %>
 
 <% if multiple && (show_select_all_top || show_select_all_bottom) %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -30,26 +30,32 @@ end
 
 <% if multiple && (show_select_all_top || show_select_all_bottom) %>
   <% select_all = capture do %>
-    <%= tag.div class: [
-        "hidden",
-        "inline-block dark:border-darkPrimary-600",
-        "border-b pb-4 mb-4": show_select_all_top && !show_select_all_bottom,
-        "border-t pt-4 mt-4": !show_select_all_top && show_select_all_bottom
-    ], data: {
-      "#{stimulus_controller}-target": "selectAllWrapper"
-    } do %>
-      <label class="relative flex items-start">
-        <div class="flex items-center h-5">
-          <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
-            "#{stimulus_controller}-target": 'selectAllCheckbox',
-            'action': "#{stimulus_controller}#selectAllOrNone"
-          }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
-        </div>
-        <div class="ml-2.5 text-sm pr-4">
-          All
-        </div>
-      </label>
-    <% end %>
+    <div class="flex">
+      <%= tag.div class: [
+          "hidden",
+          "inline-block dark:border-darkPrimary-600",
+          "border-b pb-4 mb-4": show_select_all_top && !show_select_all_bottom,
+          "border-t pt-4 mt-4": !show_select_all_top && show_select_all_bottom
+      ], data: {
+        "#{stimulus_controller}-target": "selectAllWrapper"
+      } do %>
+        <label class="relative flex items-start">
+          <div class="flex items-center h-5">
+            <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
+              "#{stimulus_controller}-target": 'selectAllCheckbox',
+              'action': "#{stimulus_controller}#selectAllOrNone"
+            }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
+          </div>
+          <div class="ml-2.5 text-sm pr-4">
+            All
+          </div>
+        </label>
+      <% end %>
+      <% if content_for? :actions_on_multiple %>
+        <%= yield :actions_on_multiple %>
+        <% flush_content_for :actions_on_multiple %>
+      <% end %>
+    </div>
   <% end %>
 <% end %>
 

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -7,39 +7,44 @@ form ||= current_fields_form
 html_options ||= {}
 html_options[:id] ||= id_for(form, method)
 multiple ||= false
-show_select_all ||= false
+show_select_all_top ||= false
+show_select_all_bottom ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
 %>
 
+<% if multiple && (show_select_all_top || show_select_all_bottom) %>
+  <% select_all = capture do %>
+    <%= tag.div class: [
+        "inline-block dark:border-darkPrimary-600",
+        "border-b pb-4 mb-4": show_select_all_top && !show_select_all_bottom,
+        "border-t pt-4 mt-4": !show_select_all_top && show_select_all_bottom
+    ] do %>
+      <label class="relative flex items-start">
+        <div class="flex items-center h-5">
+          <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
+            "#{stimulus_controller}-target": 'selectAllCheckbox',
+            'action': "#{stimulus_controller}#selectAllOrNone"
+          }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
+        </div>
+        <div class="ml-2.5 text-sm pr-4">
+          All
+        </div>
+      </label>
+    <% end %>
+  <% end %>
+<% end %>
+
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <div class="pt-1.5 pb-1 sm:col-span-2" data-controller="<%= stimulus_controller %>">
+    
+      <% if multiple && show_select_all_top && !show_select_all_bottom %>
+        <%= select_all %>
+      <% end %>
+      
       <div class="max-w-lg space-y-3">
-        
-        <% if multiple && show_select_all %>
-          <label class="relative flex items-start mb-8">
-            <div class="flex items-center h-5">
-              <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
-                "#{stimulus_controller}-target": 'selectAllCheckbox',
-                'action': "#{stimulus_controller}#selectAllOrNone"
-              }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
-            </div>
-            <div class="ml-2.5 text-sm">
-              <%= tag.div class: "select-none", data: {
-                "fields--options-target": "selectAllLabel",
-                "controller": "text-toggle",
-                "action": "click->fields--options#selectAllOrNone",
-                "text-toggle-label-value": "Select All",
-                "text-toggle-alternate-label-value": "Select None"
-              } do %>
-                Select All
-              <% end %>
-            </div>
-          </label>
-        <% end %>
-
         <% options.each do |value, label| %>
 
           <label class="relative flex items-start">
@@ -63,8 +68,12 @@ labels = labels_for(form, method)
           </label>
 
         <% end %>
-
       </div>
+
+      <% if multiple && !show_select_all_top && show_select_all_bottom %>
+        <%= select_all %>
+      <% end %>
+
     </div>
   <% end %>
 <% end %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -1,8 +1,6 @@
 <% yield %>
 
 <%
-stimulus_controller = 'fields--options'
-
 form ||= current_fields_form
 html_options ||= {}
 html_options[:id] ||= id_for(form, method)
@@ -20,10 +18,10 @@ option_field_options[:data][:controller] += " fields--field"
 
 if multiple
   option_field_options[:data] = option_field_options[:data].merge({
-    "#{stimulus_controller}-target": 'checkbox'
+    "select-all-target": 'checkbox'
   })
   option_field_options[:data][:action] ||= ""
-  option_field_options[:data][:action] += " #{stimulus_controller}#updateSelectAllCheckbox"
+  option_field_options[:data][:action] += " select-all#updateToggle"
 end
 
 %>
@@ -37,13 +35,13 @@ end
           "border-b pb-4 mb-4": show_select_all_top && !show_select_all_bottom,
           "border-t pt-4 mt-4": !show_select_all_top && show_select_all_bottom
       ], data: {
-        "#{stimulus_controller}-target": "selectAllWrapper"
+        "select-all-target": "wrapper"
       } do %>
         <label class="relative flex items-start">
           <div class="flex items-center h-5">
             <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
-              "#{stimulus_controller}-target": 'selectAllCheckbox',
-              'action': "#{stimulus_controller}#selectAllOrNone"
+              "select-all-target": 'toggleCheckbox',
+              'action': "select-all#selectAllOrNone"
             }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
           </div>
           <div class="ml-2.5 text-sm pr-4">
@@ -63,8 +61,8 @@ end
 <%= render 'shared/fields/field', form: form, method: method, options: html_options, other_options: other_options do %>
   <% content_for :field do %>
     <%= tag.div class: "pt-1.5 pb-1 sm:col-span-2", data: {
-      controller: stimulus_controller,
-      "#{stimulus_controller}-select-all-unavailable-class": "hidden"
+      controller: "select-all",
+      "select-all-unavailable-class": "hidden"
     } do %>
     
       <% if multiple && show_select_all_top && !show_select_all_bottom %>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -47,6 +47,7 @@ end
             }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
           </div>
           <div class="ml-2.5 text-sm pr-4">
+            <%# TODO: should be localized %>
             All
           </div>
         </label>

--- a/app/views/themes/tailwind_css/fields/_options.html.erb
+++ b/app/views/themes/tailwind_css/fields/_options.html.erb
@@ -7,6 +7,7 @@ form ||= current_fields_form
 html_options ||= {}
 html_options[:id] ||= id_for(form, method)
 multiple ||= false
+show_select_all ||= false
 other_options ||= {}
 options ||= options_for(form, method)
 labels = labels_for(form, method)
@@ -16,6 +17,28 @@ labels = labels_for(form, method)
   <% content_for :field do %>
     <div class="pt-1.5 pb-1 sm:col-span-2" data-controller="<%= stimulus_controller %>">
       <div class="max-w-lg space-y-3">
+        
+        <% if multiple && show_select_all %>
+          <label class="relative flex items-start mb-8">
+            <div class="flex items-center h-5">
+              <%= check_box_tag "#{html_options[:id]}-select_all", 'select-all', false, data: { 
+                "#{stimulus_controller}-target": 'selectAllCheckbox',
+                'action': "#{stimulus_controller}#selectAllOrNone"
+              }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded" %>
+            </div>
+            <div class="ml-2.5 text-sm">
+              <%= tag.div class: "select-none", data: {
+                "fields--options-target": "selectAllLabel",
+                "controller": "text-toggle",
+                "action": "click->fields--options#selectAllOrNone",
+                "text-toggle-label-value": "Select All",
+                "text-toggle-alternate-label-value": "Select None"
+              } do %>
+                Select All
+              <% end %>
+            </div>
+          </label>
+        <% end %>
 
         <% options.each do |value, label| %>
 
@@ -23,7 +46,7 @@ labels = labels_for(form, method)
             <div class="flex items-center h-5">
 
               <% if multiple %>
-                <%= form.check_box method, {multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s), data: { "#{stimulus_controller}-target": 'checkbox', 'action': "#{stimulus_controller}#updateSelectedIds" }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
+                <%= form.check_box method, {multiple: multiple, checked: form.object.send(method).map(&:to_s).include?(value.to_s), data: { "#{stimulus_controller}-target": 'checkbox', 'action': "#{stimulus_controller}#updateSelectAllCheckbox" }, class: "focus:ring-blue h-4 w-4 text-blue border-gray-300 rounded"}, value, "" %>
               <% else %>
                 <%= form.radio_button method, value, {class: "focus:ring-blue h-4 w-4 text-blue border-gray-300"} %>
               <% end %>


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-fields/issues/20

Co-dependent PRs:
* https://github.com/bullet-train-co/bullet_train-fields/pull/29
* https://github.com/bullet-train-co/bullet_train-base/pull/101

This PR modifies the default `options` field partial to include an optional Select All button.

- [x] Add an optional Select All | Select None checkbox
- [x] Consider making checking/unchecking checkboxes update the Select All label and checkbox (nope, dropping that)
- [x] Make sure multiple options fields with Select All checkbox can co-exist on a page
- [x] Make the Select All checkbox compatible with [laying options out as columns (see PR #12)](https://github.com/bullet-train-co/bullet_train-themes-tailwind_css/pull/12)
- [x] Put the Select All checkbox in an intuitive location
- [x] Make the Select All checkbox visible only if JavaScript is enabled
- [x] Add way to reset to original selected options
- [x] Abstract out select-all-controller for use in bulk-actions from action-models