### PR TITLE
add attributes/_code.html.erb with secret option

### DIFF
--- a/app/views/themes/tailwind_css/attributes/_code.html.erb
+++ b/app/views/themes/tailwind_css/attributes/_code.html.erb
@@ -1,0 +1,22 @@
+<% object ||= current_attributes_object %>
+<% strategy ||= current_attributes_strategy || :none %>
+<% source ||= nil %>
+<% url ||= nil %>
+<% secret ||= false %>
+<% if object.send(attribute).present? %>
+  <%= render 'shared/attributes/attribute', object: object, attribute: attribute, strategy: strategy, url: url do %>
+    <% if secret && source.nil? %>
+      <% attribute = object.send(attribute) %>
+      <% attribute_short = attribute[0..4] %>
+      <div class="flex flex-row">
+        <details class="group peer order-2">
+          <summary class="list-none text-xs text-primary-500 dark:text-darkAccent-200 hover:text-primary-600 hover:underline group-open:hidden cursor-pointer">Show</summary>
+          <code class="text-pink-600 font-light"><%= attribute %></code>
+        </details>
+        <code class="order-1 mr-2 peer-open:hidden text-pink-600 font-light"><%= attribute_short %><% if attribute_short.length < attribute.length %>&hellip;<% end %></code>
+      </div>
+    <% else %>
+      <code class="text-pink-600 font-light"><%= object.send(source || attribute) %></code>
+    <% end %>
+  <% end %>
+<% end %>


### PR DESCRIPTION
Closes https://github.com/bullet-train-co/bullet_train-fields/issues/32

Co-dependent PRs:

* https://github.com/bullet-train-co/bullet_train-themes-light/pull/51

This PR introduces a code attribute partial with an option to hide the code until a user takes action to reveal it.

![CleanShot 2022-09-08 at 17 09 32](https://user-images.githubusercontent.com/104179/189226595-515f6a15-9ede-4f1c-9dc1-4dd07fcf5d68.gif)

![CleanShot 2022-09-08 at 17 09 51](https://user-images.githubusercontent.com/104179/189226603-668c5585-d1c6-485b-9c32-e5353b135265.gif)
